### PR TITLE
Bugfix

### DIFF
--- a/src/com/darkblade12/particleeffect/ParticleEffect.java
+++ b/src/com/darkblade12/particleeffect/ParticleEffect.java
@@ -1409,6 +1409,9 @@ public enum ParticleEffect {
 		 * @return The version number
 		 */
 		public static int getVersion() {
+			if (!initialized) {
+				initialize();
+			}
 			return version;
 		}
 


### PR DESCRIPTION
Sometimes getVersion would be called when everything wasn't initiazed, that caused getVErsion to give wrong results. This fixes that.