### PR TITLE
Update ParticleEffect.java

### DIFF
--- a/src/com/darkblade12/particleeffect/ParticleEffect.java
+++ b/src/com/darkblade12/particleeffect/ParticleEffect.java
@@ -1081,6 +1081,20 @@ public enum ParticleEffect {
 		private final int green;
 		private final int blue;
 
+/**
+		 * Construct a new ordinary color
+		 * 
+		 * @param color Color from org.bukkit.Color
+		 */
+		public OrdinaryColor(org.bukkit.Color color){
+			if (color.getRed() == 0) {
+				this.red = 1;
+			}else{
+				this.red = color.getRed();
+			}
+			this.green = color.getGreen();
+			this.blue = color.getBlue();
+		}
 		/**
 		 * Construct a new ordinary color
 		 * 
@@ -1096,7 +1110,11 @@ public enum ParticleEffect {
 			if (red > 255) {
 				throw new IllegalArgumentException("The red value is higher than 255");
 			}
-			this.red = red;
+			if (red == 0) {
+				this.red = 1;
+			}else{
+				this.red = red;
+			}
 			if (green < 0) {
 				throw new IllegalArgumentException("The green value is lower than 0");
 			}


### PR DESCRIPTION
Solve bug from redstone particles that not show the correct color
added new OrdinaryColor(Color) for example new OrdinaryColor(Color.BLUE)