### PR TITLE
Add scope to Bukkit dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
             <version>1.8.7-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     
@@ -42,7 +43,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.3</version>
-                <scope>provided</scope>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.3</version>
+                <scope>provided</scope>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This will (hopefully) remove the need for the `<artifactSet>` I currently must set to make sure Bukkit isn't pulled into my JAR when shading.