### PR TITLE
Optimize packets by only caring about the given world

### DIFF
--- a/src/main/java/com/darkblade12/particleeffect/ParticleEffect.java
+++ b/src/main/java/com/darkblade12/particleeffect/ParticleEffect.java
@@ -5,6 +5,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
@@ -1526,13 +1527,12 @@ public enum ParticleEffect {
 			if (range < 1) {
 				throw new IllegalArgumentException("The range is lower than 1");
 			}
-			String worldName = center.getWorld().getName();
+
 			double squared = range * range;
-			for (Player player : Bukkit.getOnlinePlayers()) {
-				if (!player.getWorld().getName().equals(worldName) || player.getLocation().distanceSquared(center) > squared) {
-					continue;
+			for (Player player : center.getWorld().getPlayers()) {
+				if (player.getLocation().distanceSquared(center) <= squared) {
+					sendTo(center, player);
 				}
-				sendTo(center, player);
 			}
 		}
 


### PR DESCRIPTION
Instead of checking against each player currently online on the server, we only care about the currently residing players for the given location's world. This not only drops the world name check, but also drasticly reduces the number of players to check if a world has almost no people in it, while the server might be packed.
