### PR TITLE
Update to support versions above 1.9 (ie v1.10/v1.13)

### DIFF
--- a/src/main/java/com/darkblade12/particleeffect/ParticleEffect.java
+++ b/src/main/java/com/darkblade12/particleeffect/ParticleEffect.java
@@ -1403,7 +1403,7 @@ public enum ParticleEffect {
 				return;
 			}
 			try {
-				version = Integer.parseInt(Character.toString(PackageType.getServerVersion().charAt(3)));
+				version = Integer.parseInt(PackageType.getServerVersion().split("_")[1]);
 				if (version > 7) {
 					enumParticle = PackageType.MINECRAFT_SERVER.getClass("EnumParticle");
 				}


### PR DESCRIPTION
e.g.  v1_12_R2, using .split("_")[1] to get 12 instead of charAt(3) which gets only 1